### PR TITLE
Add hash helper for anulaciones and compute Alta fingerprint

### DIFF
--- a/Tests/QuickSendAlta.cs
+++ b/Tests/QuickSendAlta.cs
@@ -111,7 +111,7 @@ public static class QuickSendAlta
 
     private static RegistroAlta BuildAlta()
     {
-        return new RegistroAlta
+        var alta = new RegistroAlta
         {
             // y redeclarar xmlns sum1 en RegistroAlta:
             Xmlns = new XmlSerializerNamespaces(
@@ -187,9 +187,11 @@ public static class QuickSendAlta
                 IndicadorMultiplesOT = "N"
             },
             FechaHoraHusoGenRegistro = "2025-08-20T09:30:17Z",
-            TipoHuella = "01",
-            Huella = "ouBerxDICH/3kSYlLfnuga3ja6qu3+6po1c9h9743sQ="
         };
+
+        alta.TipoHuella = "01";
+        alta.Huella = HuellaHelper.ComputeHuellaRegistroAlta(alta);
+        return alta;
     }
 
     private static X509Certificate2 LoadClientCertificate(string pfxPath, string? password)

--- a/Verifactu/Models/Common/Hash/HuellaHelper.cs
+++ b/Verifactu/Models/Common/Hash/HuellaHelper.cs
@@ -58,4 +58,30 @@ public static class HuellaHelper
         var hash = sha.ComputeHash(bytes);
         return Convert.ToBase64String(hash);
     }
+
+    /// <summary>
+    /// Calcula la huella del <see cref="RegistroAnulacion"/> con un canónico predecible.
+    /// </summary>
+    public static string ComputeHuellaRegistroAnulacion(RegistroAnulacion anulacion)
+    {
+        // Canon mínimo: IDVersion|IDEmisorFactura|NumSerie|Fecha|RechazoPrevio|SinRegistroPrevio|FechaHoraHusoGenRegistro
+        // *Sin espacios*, *separado por '|'* y valores nulos como "".
+        string S(string? v) => v?.Trim() ?? "";
+
+        var canon = string.Join("|", new[]
+        {
+            S(anulacion.IDVersion),
+            S(anulacion.IDFacturaAnulada?.IDEmisorFacturaAnulada),
+            S(anulacion.IDFacturaAnulada?.NumSerieFacturaAnulada),
+            S(anulacion.IDFacturaAnulada?.FechaExpedicionFacturaAnulada),
+            S(anulacion.RechazoPrevio),
+            S(anulacion.SinRegistroPrevio),
+            S(anulacion.FechaHoraHusoGenRegistro)
+        });
+
+        using var sha = SHA256.Create();
+        var bytes = Encoding.UTF8.GetBytes(canon);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToBase64String(hash);
+    }
 }


### PR DESCRIPTION
## Summary
- add SHA-256 huella calculator for `RegistroAnulacion`
- compute Alta huella with helper in sample instead of hardcoded string

## Testing
- `dotnet build Tests/Tests.csproj`
- `dotnet test Tests/Tests.csproj` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68a84fff4f308333896f67002066c92b