### PR TITLE
Handle mix names when comparing song titles

### DIFF
--- a/matcher.py
+++ b/matcher.py
@@ -1,0 +1,23 @@
+import re
+from difflib import SequenceMatcher
+
+
+def normalize_mix_name(title: str) -> str:
+    """Remove content in parentheses or brackets, often mix names."""
+    return re.sub(r'\s*[\(\[].*?[\)\]]', '', title).strip()
+
+
+def compare_titles(t_vk: str, t_down: str, threshold: float = 0.9) -> bool:
+    """Compare titles, ignoring mix name if initial match is below threshold."""
+    ratio = SequenceMatcher(None, t_vk, t_down).ratio()
+    if ratio >= threshold:
+        return True
+    t_down_no_mix = normalize_mix_name(t_down)
+    ratio_no_mix = SequenceMatcher(None, t_vk, t_down_no_mix).ratio()
+    return ratio_no_mix >= threshold
+
+
+if __name__ == "__main__":
+    vk_title = "Artist - Track"
+    downloaded_title = "Artist - Track (Extended Mix)"
+    print(compare_titles(vk_title, downloaded_title))


### PR DESCRIPTION
## Summary
- add `normalize_mix_name` helper to strip mix names
- add `compare_titles` to try matching with and without mix names

## Testing
- `python matcher.py`

------
https://chatgpt.com/codex/tasks/task_b_68a8cd1349d48333bd281f669ebbefe4